### PR TITLE
通知系は非同期で処理する / Slack のAPI例外を致命エラーじゃなくする

### DIFF
--- a/src/outerApiErrorReport.ts
+++ b/src/outerApiErrorReport.ts
@@ -30,20 +30,24 @@ export const ipcNormalizationErrorReport = async (identifier: string, metadata: 
     text: `*入力住所*\n${prenormalized}`,
   });
 
-  await sendSlackNotification({
-    channel: 'dev-ipc-normalize-errors-notifications',
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*${title}*`,
+  try {
+    await sendSlackNotification({
+      channel: 'dev-ipc-normalize-errors-notifications',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*${title}*`,
+          },
         },
-      },
-      {
-        type: 'section',
-        fields,
-      },
-    ],
-  });
+        {
+          type: 'section',
+          fields,
+        },
+      ],
+    });
+  } catch (e: any) {
+    console.log('Slack notification failed with error: ', e);
+  }
 };


### PR DESCRIPTION
大量にエラーが発生すると、 Slack のAPIレートリミットに引っかかるけど、システムの動きには関係ないので無視しても大丈夫。