### PR TITLE
geocoding_level が 7 未満の場合、 normalization_failed エラーを返す

### DIFF
--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -205,23 +205,33 @@ https://api.propid.jp/v1
 
 <table>
   <tr>
+    <th>解析レベル</th>
     <th>解析レベルの数字</th>
+    <th>エラー時の値</th>
     <th>説明</th>
   </tr>
   <tr>
+    <td>解析できません</td>
     <td>0</td>
+    <td><code>prefecture_not_recognized</code></td>
     <td>都道府県も判別できなかった</td>
   </tr>
   <tr>
+    <td>都道府県</td>
     <td>1</td>
+    <td><code>city_not_recognized</code></td>
     <td>都道府県まで判別できた</td>
   </tr>
   <tr>
+    <td>市区町村</td>
     <td>2</td>
+    <td><code>neighborhood_not_recognized</code></td>
     <td>市区町村まで判別できた</td>
   </tr>
   <tr>
+    <td>町丁目</td>
     <td>3</td>
+    <td></td>
     <td>町丁目まで判別できた</td>
   </tr>
 </table>
@@ -232,46 +242,55 @@ https://api.propid.jp/v1
   <tr>
     <th>解析レベル</th>
     <th>レベルの数字</th>
+    <th>エラー時の値</th>
     <th>説明</th>
   </tr>
   <tr>
     <td>都道府県</td>
     <td>1</td>
+    <td><code>geo_prefecture</code><td>
     <td>県レベルでマッチしました</td>
   </tr>
   <tr>
     <td>市区町村</td>
     <td>2</td>
+    <td><code>geo_city</code><td>
     <td>市区町村レベルでマッチしました</td>
   </tr>
   <tr>
     <td>町域 (大字)	</td>
     <td>3</td>
+    <td><code>geo_oaza</code><td>
     <td>町域レベルでマッチしました</td>
   </tr>
   <tr>
     <td>丁目 / 小字	</td>
     <td>4</td>
+    <td><code>geo_koaza</code><td>
     <td>丁目または小字レベルでマッチしました</td>
   </tr>
   <tr>
     <td>番地（番）</td>
     <td>5</td>
+    <td><code>geo_banchi</code><td>
     <td>番地（番）レベルでマッチしました</td>
   </tr>
   <tr>
     <td>号情報が存在しない番地</td>
     <td>7</td>
+    <td><code>geo_ok_no_go</code><td>
     <td>番地（番）レベルでマッチしました（号情報が存在しない地域）</td>
   </tr>
   <tr>
     <td>号</td>
     <td>8</td>
+    <td><code>geo_ok_go</code><td>
     <td>号レベルでマッチしました</td>
   </tr>
   <tr>
     <td>不明</td>
     <td>-1</td>
+    <td><code>geo_undefined</code><td>
     <td>不明</td>
   </tr>
 </table>

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -71,25 +71,27 @@ test('should return the same ID for query with empty building', async () => {
   const event1 = {
     isDemoMode: true,
     queryStringParameters: {
-      q: '岩手県盛岡市盛岡駅西通２丁目９番地2号',
+      q: '岩手県盛岡市盛岡駅西通２丁目6番地5号',
     },
   }
   const event2 = {
     isDemoMode: true,
     queryStringParameters: {
-      q: '岩手県盛岡市盛岡駅西通２丁目９番地2号',
+      q: '岩手県盛岡市盛岡駅西通２丁目6番地5号',
       building: '',
     },
   };
   // @ts-ignore
   const lambdaResult1 = await handler(event1) as APIGatewayProxyResult;
   const body1 = JSON.parse(lambdaResult1.body);
+  expect(body1.error).not.toStrictEqual(true);
   expect(body1.length).toStrictEqual(1);
 
   // @ts-ignore
   const lambdaResult2 = await handler(event2) as APIGatewayProxyResult;
   const body2 = JSON.parse(lambdaResult2.body);
-  expect(body1.length).toStrictEqual(1);
+  expect(body2.error).not.toStrictEqual(true);
+  expect(body2.length).toStrictEqual(1);
 
   expect(body1[0].ID).toEqual(body2[0].ID);
 });
@@ -98,25 +100,27 @@ test('should return the same ID for queries with a different building name', asy
   const event1 = {
     isDemoMode: true,
     queryStringParameters: {
-      q: '岩手県盛岡市盛岡駅西通２丁目９番地10号',
+      q: '岩手県盛岡市盛岡駅西通２丁目９番地1号',
     },
   }
   const event2 = {
     isDemoMode: true,
     queryStringParameters: {
-      q: '岩手県盛岡市盛岡駅西通２丁目９番地10号',
+      q: '岩手県盛岡市盛岡駅西通２丁目９番地1号',
       building: 'おはようビル2.9.10棟',
     },
   }
   // @ts-ignore
   const lambdaResult1 = await handler(event1) as APIGatewayProxyResult;
   const body1 = JSON.parse(lambdaResult1.body);
+  expect(body1.error).not.toStrictEqual(true);
   expect(body1.length).toStrictEqual(1);
 
   // @ts-ignore
   const lambdaResult2 = await handler(event2) as APIGatewayProxyResult;
   const body2 = JSON.parse(lambdaResult2.body);
-  expect(body1.length).toStrictEqual(1);
+  expect(body2.error).not.toStrictEqual(true);
+  expect(body2.length).toStrictEqual(1);
 
   expect(body1[0].ID).toEqual(body2[0].ID);
 });
@@ -276,13 +280,13 @@ test('should get estate ID without details if authenticated with a free API key'
   expect(first.location).toBeUndefined()
 })
 
-test('should get estate ID with details if authenticated with 和歌山県東牟婁郡串本町田並1500', async () => {
+test('should get estate ID with details if authenticated with 和歌山県東牟婁郡串本町田並1300', async () => {
   const { apiKey, accessToken } = await dynamodb.createApiKey('should get estate ID with details if authenticated')
 
   const event = {
     isDemoMode: true,
     queryStringParameters: {
-      q: '和歌山県東牟婁郡串本町田並1500',
+      q: '和歌山県東牟婁郡串本町田並1300',
       'api-key': apiKey
     },
     headers: {
@@ -296,19 +300,19 @@ test('should get estate ID with details if authenticated with 和歌山県東牟
   expect(body).toEqual([
     expect.objectContaining({
       "normalization_level": "3",
-      "geocoding_level": "3",
+      "geocoding_level": "7",
       "address": {
         "ja": {
           "address1": "田並",
-          "address2": "1500",
+          "address2": "1300",
           "city": "東牟婁郡串本町",
           "other": "",
           "prefecture": "和歌山県",
         },
       },
       "location": {
-        "lat": "33.488638",
-        "lng": "135.714765",
+        "lat": "33.49016",
+        "lng": "135.716715",
       },
     })
   ])
@@ -321,6 +325,8 @@ describe("normalization error cases",  () => {
       ['和歌山県aoeu', 'city_not_recognized'],
       ['和歌県', 'prefecture_not_recognized'],
       ['おはよう', 'prefecture_not_recognized'],
+      ['東京都千代田区飯田橋１丁目', 'geo_koaza'],
+      ['東京都千代田区飯田橋１丁目３', 'geo_banchi'],
     ]
 
     for (const addressData of addresses) {

--- a/src/public.ts
+++ b/src/public.ts
@@ -138,14 +138,12 @@ export const _handler: Handler<PublicHandlerEvent, APIGatewayProxyResult> = asyn
   const prefCode = getPrefCode(feature.properties.pref);
   const { x, y } = coord2XY([lat, lng], ZOOM);
 
-  if (geocoding_level_int <= 4 ) {
+  if (geocoding_level_int <= 6) {
     background.push(ipcNormalizationErrorReport('normLogsIPCGeom', {
       prenormalized: normalizedAddressNJA,
       geocoding_level: geocoding_level,
     }));
-  }
 
-  if (geocoding_level_int <= 6) {
     const error_code_detail = (
       IPC_NORMALIZATION_ERROR_CODE_DETAILS[geocoding_level_int.toString()]
       || IPC_NORMALIZATION_ERROR_CODE_DETAILS['-1']


### PR DESCRIPTION
* geocoding_level が 7 未満の場合、 normalization_failed エラーを返す
* 不正な住所をテストから削除し、実在する住所と入れ替え
* ドキュメントに normalization_failed の値を追加