### PR TITLE
Keep logs when IPC normalization is not sufficient

### DIFF
--- a/src/public.ts
+++ b/src/public.ts
@@ -147,6 +147,12 @@ export const _handler: Handler<PublicHandlerEvent, APIGatewayProxyResult> = asyn
       // 内部で番地号情報がありました。
       finalNormalized = internalBGNormalized;
     }
+
+    background.push(createLog('normLogsIPCFail', {
+      prenormalized: prenormalizedStr,
+      ipcLevel: geocoding_level_int,
+      intBGLevel: internalBGNormalized.level,
+    }));
   }
 
   if (finalNormalized.level <= 6 && geocoding_level_int <= 6) {


### PR DESCRIPTION
外部データベースが不完全な応答になってる場合に、 logs DB に記録する。
内部データベースで補完された場合も、その補完済みlevelを記録する