### PR TITLE
Fix log stream error with no yyyy-mm-dd postfix

### DIFF
--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -42,7 +42,7 @@ export const _handler: DynamoDBStreamHandler = async (event) => {
       }
 
       const [type, logType, date] = (PK as string).split('#');
-      const [year, month, day] = date.split('-');
+      const [year, month, day] = (date || '').split('-');
       if (
         type === 'LOG' &&
         logType &&


### PR DESCRIPTION
ログをパースする際に `AddrDB#東京都新宿区新宿六丁目` のようなパーティションキーが入ってくることを想定していなかったため修正しました。