### PR TITLE
Use NDJSON source

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@slack/webhook": "^6.0.0",
     "auth0": "^2.37.0",
     "axios": "^0.24.0",
-    "json2csv": "^5.0.6",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.5",
     "luxon": "^2.1.1",

--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -36,6 +36,6 @@ test('should store log as s3 object', async () => {
   await logEvent._handler(event, {} as any, () => {})
   expect(key).toMatch(/^year=2021\/month=01\/day=01\/[0-9]*\.csv\.gz$/)
   console.log(body)
-  expect(body).toEqual(`"id","logType","userId","apiKey","createAt","json"
-"my-sort-key","MY-LOG-TYPE",,"my-api-key","${now}","{""prop1"":""abc"",""prop2"":123}"`)
+  expect(body).toEqual(`"id"\t"logType"\t"userId"\t"apiKey"\t"createAt"\t"json"
+"my-sort-key"\t"MY-LOG-TYPE"\t\t"my-api-key"\t"${now}"\t"{""prop1"":""abc""\t""prop2"":123}"`)
 })

--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -34,7 +34,15 @@ test('should store log as s3 object', async () => {
     ]
   }
   await logEvent._handler(event, {} as any, () => {})
-  expect(key).toMatch(/^year=2021\/month=01\/day=01\/[0-9]*\.csv\.gz$/)
-  expect(body).toEqual(`"id"\t"logType"\t"userId"\t"apiKey"\t"createAt"\t"json"
-"my-sort-key"\t"MY-LOG-TYPE"\t\t"my-api-key"\t"${now}"\t"{""prop1"":""abc"",""prop2"":123}"`)
+  expect(key).toMatch(/^year=2021\/month=01\/day=01\/[0-9]*\.json\.gz$/)
+  expect(body).toEqual(JSON.stringify([{
+    id: 'my-sort-key',
+    logType: 'MY-LOG-TYPE',
+    apiKey: 'my-api-key',
+    createAt: now,
+    others: {
+      prop1: 'abc',
+      prop2: 123,
+    }
+  }]))
 })

--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -40,7 +40,7 @@ test('should store log as s3 object', async () => {
     logType: 'MY-LOG-TYPE',
     apiKey: 'my-api-key',
     createAt: now,
-    others: {
+    data: {
       prop1: 'abc',
       prop2: 123,
     }

--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -3,13 +3,12 @@ import * as logEvent from './logEvents'
 import zlib from 'zlib'
 
 test('should store log as s3 object', async () => {
-  let key, body
+  const putObjectArgs: { key: string, body: Buffer }[] = []
   // @ts-ignore
   logEvent.s3 = {
     putObject: ({ Key, Body }: { Key: string, Body: Buffer }) => ({
       promise: () => new Promise<void>(resolve => {
-        key = Key
-        body = zlib.gunzipSync(Body as unknown as Buffer).toString('utf-8'),
+        putObjectArgs.push({key: Key, body: Body })
         resolve()
       })
     })
@@ -22,27 +21,82 @@ test('should store log as s3 object', async () => {
         eventName: 'INSERT',
         dynamodb: {
           NewImage: {
-            PK: { S: 'LOG#MY-LOG-TYPE#2021-01-01' },
-            SK: { S: 'my-sort-key' },
-            apiKey: { S: 'my-api-key' },
+            PK: { S: 'LOG#MY-LOG-TYPE1#2021-01-01' },
+            SK: { S: 'my-sort-key1-1' },
+            apiKey: { S: 'my-api-key1-1' },
             createAt: { S: now },
             prop1: { S: 'abc' },
-            prop2: { N: '123' }
+            prop2: { N: '123' },
+          }
+        }
+      },
+      {
+        eventName: 'INSERT',
+        dynamodb: {
+          NewImage: {
+            PK: { S: 'LOG#MY-LOG-TYPE2#2021-01-01' },
+            SK: { S: 'my-sort-key1-2' },
+            apiKey: { S: 'my-api-key1-2' },
+            createAt: { S: now },
+            prop1: { S: 'abc' },
+            prop2: { N: '123' },
+          }
+        }
+      },
+      {
+        eventName: 'INSERT',
+        dynamodb: {
+          NewImage: {
+            PK: { S: 'LOG#MY-LOG-TYPE2#2021-01-02' },
+            SK: { S: 'my-sort-key2' },
+            apiKey: { S: 'my-api-key2' },
+            createAt: { S: now },
+            prop1: { S: 'abc' },
+            prop2: { N: '123' },
+            prop3: { S: 'あああ' },
           }
         }
       }
     ]
   }
+
   await logEvent._handler(event, {} as any, () => {})
-  expect(key).toMatch(/^year=2021\/month=01\/day=01\/[0-9]*\.json\.gz$/)
-  expect(body).toEqual(JSON.stringify([{
-    id: 'my-sort-key',
-    logType: 'MY-LOG-TYPE',
-    apiKey: 'my-api-key',
-    createAt: now,
-    data: {
-      prop1: 'abc',
-      prop2: 123,
-    }
-  }]))
+
+  expect(putObjectArgs[0].key).toMatch(/^json\/year=2021\/month=01\/day=01\/[0-9]*\.json\.gz$/)
+  expect(putObjectArgs[1].key).toMatch(/^json\/year=2021\/month=01\/day=02\/[0-9]*\.json\.gz$/)
+  const body0 = zlib.gunzipSync(putObjectArgs[0].body).toString('utf-8')
+  const body1 = zlib.gunzipSync(putObjectArgs[1].body).toString('utf-8')
+  expect(body0).toEqual(
+    [
+      {
+        id: 'my-sort-key1-1',
+        logType: 'MY-LOG-TYPE1',
+        apiKey: 'my-api-key1-1',
+        createAt: now,
+        json: JSON.stringify({ prop1: 'abc', prop2: 123 }),
+      },
+      {
+        id: 'my-sort-key1-2',
+        logType: 'MY-LOG-TYPE2',
+        apiKey: 'my-api-key1-2',
+        createAt: now,
+        json: JSON.stringify({ prop1: 'abc', prop2: 123 }),
+      },
+    ]
+      .map(obj => JSON.stringify(obj))
+      .join('\n')
+  )
+  expect(body1).toEqual(
+    [
+      {
+        id: 'my-sort-key2',
+        logType: 'MY-LOG-TYPE2',
+        apiKey: 'my-api-key2',
+        createAt: now,
+        json: JSON.stringify({ prop1: 'abc', prop2: 123, prop3: 'あああ' }),
+      },
+    ]
+      .map(obj => JSON.stringify(obj))
+      .join('\n')
+  )
 })

--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -35,7 +35,6 @@ test('should store log as s3 object', async () => {
   }
   await logEvent._handler(event, {} as any, () => {})
   expect(key).toMatch(/^year=2021\/month=01\/day=01\/[0-9]*\.csv\.gz$/)
-  console.log(body)
   expect(body).toEqual(`"id"\t"logType"\t"userId"\t"apiKey"\t"createAt"\t"json"
-"my-sort-key"\t"MY-LOG-TYPE"\t\t"my-api-key"\t"${now}"\t"{""prop1"":""abc""\t""prop2"":123}"`)
+"my-sort-key"\t"MY-LOG-TYPE"\t\t"my-api-key"\t"${now}"\t"{""prop1"":""abc"",""prop2"":123}"`)
 })

--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -66,7 +66,7 @@ export const _handler: DynamoDBStreamHandler = async (event) => {
   const promises = Object.keys(recordMap).map((key) => {
     const items = recordMap[key];
 
-    const json2csvParser = new Json2csvParser();
+    const json2csvParser = new Json2csvParser({ delimiter: '\t' });
     const csv = json2csvParser.parse(items);
     const body = zlib.gzipSync(csv);
 

--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -25,7 +25,7 @@ export const _handler: DynamoDBStreamHandler = async (event) => {
         SK,
         apiKey,
         createAt,
-        ...others
+        ...data
       } = item;
       let userId = item.userId || ((typeof apiKey === 'string') ? keyOwnerCache[apiKey] : undefined);
 
@@ -53,7 +53,7 @@ export const _handler: DynamoDBStreamHandler = async (event) => {
           prev[key] = [];
         }
         // SK is unique because it is numbered by ULID.
-        const item = { id: SK as string, logType, userId, apiKey, createAt, others };
+        const item = { id: SK as string, logType, userId, apiKey, createAt, data };
         prev[key].push(item);
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3492,11 +3492,6 @@ commander@^2.19.0, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
-
 commander@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -6614,15 +6609,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2csv@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-5.0.6.tgz#590e0e1b9579e59baa53bda0c0d840f4d8009687"
-  integrity sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==
-  dependencies:
-    commander "^6.1.0"
-    jsonparse "^1.3.1"
-    lodash.get "^4.4.2"
-
 json5@2.x, json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
@@ -6652,11 +6638,6 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonparse@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsonpath-plus@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
~Athena でCSVを読み込む設定をするときに、JSONを含む複雑なカンマ区切りの CSV をパースできるように設定できなかったのでタブを使うようにしました。~
データソースとして改行区切り JSON を S3 にアップロードするようにしました。

関連: https://github.com/geolonia/infrastructure/pull/5