### PR TITLE
Use internal normalization when geocoding level 3 is returned by IPC …

### DIFF
--- a/src/lib/dynamodb_logs.test.ts
+++ b/src/lib/dynamodb_logs.test.ts
@@ -70,6 +70,9 @@ describe('normalizeBanchiGo', () => {
       { addr: '東京都文京区水道二丁目', bg: '2' },
       { addr: '東京都町田市木曽東四丁目', bg: '14-イ22' },
       { addr: '大阪府大阪市中央区久太郎町四丁目', bg: '渡辺3'},
+      { addr: '愛知県名古屋市名東区宝が丘', bg: '212' },
+      { addr: '神奈川県横浜市緑区三保町', bg: '2020' },
+      { addr: '京都府京都市下京区杉屋町', bg: '270' },
     ];
 
     await Promise.all(
@@ -88,6 +91,9 @@ describe('normalizeBanchiGo', () => {
     ['東京都文京区水道2丁目2 おはようビル', { addr: '2', building: 'おはようビル', level: 7 }],
     ['東京都町田市木曽東四丁目14-イ22ビル名205', { addr: '14-イ22', building: 'ビル名205', level: 8 }],
     ['大阪府大阪市中央区久太郎町四丁目渡辺3小原流ホール', { addr: '渡辺3', building: '小原流ホール', level: 7 }],
+    ['愛知県名古屋市名東区宝が丘212おはようビル', { addr: '212', building: 'おはようビル', level: 7 }],
+    ['神奈川県横浜市緑区三保町2020', { addr: '2020', building: '', level: 7 }],
+    ['京都府京都市下京区杉屋町270おはようビル5', { addr: '270', building: 'おはようビル5', level: 7 }],
   ];
 
   for (const [inputAddr, matching] of cases) {

--- a/src/public.ts
+++ b/src/public.ts
@@ -137,8 +137,8 @@ export const _handler: Handler<PublicHandlerEvent, APIGatewayProxyResult> = asyn
   const prefCode = getPrefCode(feature.properties.pref);
   const { x, y } = coord2XY([lat, lng], ZOOM);
 
-  if (geocoding_level_int === 4 || geocoding_level_int === 5) {
-    /* IPC からの返答が 4 または 5 の場合（つまり、番地が認識できなったまたは、
+  if (geocoding_level_int >= 3 && geocoding_level_int <= 5) {
+    /* IPC からの返答が 3, 4, 5 の場合（つまり、番地が認識できなったまたは、
      * 番地は認識できたけど号が認識できなかった）は、自分のデータベースを問い合わせ、
      * 実在するかの確認を取ります。
      */


### PR DESCRIPTION
…in addition to 4 and 5

geocoding_level=3も追加しました。level=3 と level=4 の違いは大字・小字なので、level=3でも大字までマッチしたけどその後の文字列は認識できなかったというエラーなので、その後 internal normalization を確認すればbanchigoのデータベースを参照するようになる