### PR TITLE
addressPending ステータスの発行対象を拡張

### DIFF
--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -77,7 +77,7 @@ describe('IncrementP Verification API', () => {
             }
           }
         ],
-        "attribution": "(c) INCREMENT P CORPORATION"
+        "attribution": "(c) GeoTechnologies Inc."
       })
   })
 
@@ -115,7 +115,7 @@ describe('IncrementP Verification API', () => {
           }
         }
       ],
-      attribution: '(c) INCREMENT P CORPORATION'
+      attribution: '(c) GeoTechnologies Inc.'
     })
   })
 

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -521,6 +521,7 @@ describe('banchi-go database', () => {
     ['大阪府大阪市中央区久太郎町三丁目渡辺3小原流ホール', '小原流ホール',, { status: undefined }],
     ['東京都文京区水道2丁目1-9999マンションGLV5NLV3', '', { geocoding_level: '5', normalization_level: '3' }, { status: 'addressPending' }],
     ['東京都文京区水道2丁目1-9998マンションGLV5NLV8', 'マンションGLV5NLV8', { geocoding_level: '5', normalization_level: '8' }, { status: undefined }],
+    ['大阪府高槻市富田町1-999-888', '', { geocoding_level: '4', normalization_level: '3' }, { status: 'addressPending' }],
   ];
 
   for (const [inputAddr, building, expectedNormResult, expectedIdObject] of cases) {


### PR DESCRIPTION
この変更により、例えば `大阪府高槻市富田町1丁目` の入力値に対しては不十分な住所 (丁目以下が存在しない) としてエラーを返却しつつ、`大阪府高槻市富田町1丁目999-888` のように未知の番地号を含む住所に対して `addressPending` のステータスを発行することができるようになります。

`ipc_geocoding_level_int === 4` の時の限定的な状況（番地号以下に未正規化の文字列が存在する）への対処が抜けていました。申し訳ありません。