### PR TITLE
Slack の投稿フォーマットを見やすくなるように改善

### DIFF
--- a/src/idEvents.ts
+++ b/src/idEvents.ts
@@ -4,7 +4,6 @@ import AWS from 'aws-sdk';
 import Sentry from './lib/sentry';
 import { EstateId, DB } from './lib/dynamodb';
 import { sendSlackNotification } from './lib/slack';
-import type { PlainTextElement, MrkdwnElement, SectionBlock } from '@slack/types';
 
 const _findDuplicateAddress = async (estateId: EstateId) => {
   const resp = await DB.query({


### PR DESCRIPTION
 サンプル:
 
<img width="643" alt="スクリーンショット 2022-01-25 15 12 52" src="https://user-images.githubusercontent.com/6292312/150921740-5d09f465-da45-4ba0-915e-9c50a942f165.png">

list-style-type をちゃんとマークダウンで表示したかったのですが、webhook 経由で `mrkdwn` でポストしてもフォーマットされないようで、 `•` を使いました。