### PR TITLE
Add updatedat and createdat

### DIFF
--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -265,3 +265,19 @@ describe('getResetQuotaTime', () => {
     expect(actualResetTime).toStrictEqual('2021-06-01T00:00:00.000+09:00')
   })
 })
+
+test('createdAt and updatedAt params', async () => {
+  const now = '2022-01-01T00:00:00.000Z'
+  await dynamodb.store({
+    rawAddress: "京都市中京区寺町通御池上る上本能寺前町488番地",
+    address: "京都市中京区寺町通御池上る上本能寺前町488番地",
+    rawBuilding: "テストビル",
+    building: "テストビル",
+    tileXY: "3726576/1649778",
+    zoom: 22,
+    prefCode: "11",
+  })
+  const idObj = await dynamodb.getEstateIdForAddress('京都市中京区寺町通御池上る上本能寺前町488番地')
+  expect(typeof idObj[0].createdAt).toEqual('string')
+  expect(typeof idObj[0].updatedAt).toEqual('string')
+})

--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -278,6 +278,10 @@ test('createdAt and updatedAt params', async () => {
     prefCode: "11",
   })
   const idObj = await dynamodb.getEstateIdForAddress('京都市中京区寺町通御池上る上本能寺前町488番地')
+  expect(typeof idObj[0].createdAt).toEqual('string')
+  expect(typeof idObj[0].updatedAt).toEqual('string')
+  // @ts-ignore
   expect(new Date(idObj[0].createdAt).getTime()).not.toBeNaN()
+  // @ts-ignore
   expect(new Date(idObj[0].updatedAt).getTime()).not.toBeNaN()
 })

--- a/src/lib/dynamodb.test.ts
+++ b/src/lib/dynamodb.test.ts
@@ -267,7 +267,7 @@ describe('getResetQuotaTime', () => {
 })
 
 test('createdAt and updatedAt params', async () => {
-  const now = '2022-01-01T00:00:00.000Z'
+  const now =
   await dynamodb.store({
     rawAddress: "京都市中京区寺町通御池上る上本能寺前町488番地",
     address: "京都市中京区寺町通御池上る上本能寺前町488番地",
@@ -278,6 +278,6 @@ test('createdAt and updatedAt params', async () => {
     prefCode: "11",
   })
   const idObj = await dynamodb.getEstateIdForAddress('京都市中京区寺町通御池上る上本能寺前町488番地')
-  expect(typeof idObj[0].createdAt).toEqual('string')
-  expect(typeof idObj[0].updatedAt).toEqual('string')
+  expect(new Date(idObj[0].createdAt).getTime()).not.toBeNaN()
+  expect(new Date(idObj[0].updatedAt).getTime()).not.toBeNaN()
 })

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -34,6 +34,9 @@ export interface BaseEstateId {
   building?: string
   rawBuilding?: string
   status?: 'confirmed' | 'addressPending' | undefined
+
+  createdAt?: string
+  updatedAt?: string
 }
 
 export interface ConsolidatedEstateId extends BaseEstateId {
@@ -214,10 +217,13 @@ export const store = async (idObj: StoreEstateIdReq): Promise<EstateId> => {
       tries += 1;
       const serial = _generateSerial();
       const [x, y] = idObj.tileXY.split('/');
+      const now = new Date().toISOString();
       const Item: EstateId = {
         ...idObj,
         estateId: `${idObj.prefCode}-${hashXY(x, y, serial)}`,
         serial,
+        createdAt: now,
+        updatedAt: now,
       };
       const putItemInput: AWS.DynamoDB.DocumentClient.PutItemInput = {
         TableName: process.env.AWS_DYNAMODB_ESTATE_ID_TABLE_NAME,


### PR DESCRIPTION
`createdAt` と `updatedAt` を保存するようにしました。
`updatedAt` が自動で書きかわることは今の所ないのですが、 addressPending のレビュー時などに更新しようと思います。
API レスポンスには含めていません。