### PR TITLE
Slack でレビューするインタラクションの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ $ node ./bin/list-api-keys.mjs
 - `normLogsIPCFail` -  IPC リクエストに成功したが、番地・号の情報が得られなかった場合
 - `idIssSts` - ID の発行に成功した
 - `feedbackRequest` - フィードバック受付
+- `feedbackRequestReview` - フィードバックに対するレビュー
 
 ### DB の回帰テストを実行
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@geolonia/eslint-config": "^0.0.1",
     "@sentry/serverless": "^6.2.3",
     "@shelf/jest-dynamodb": "^2.2.3",
-    "@slack/types": "^2.2.0",
+    "@slack/types": "^2.4.0",
     "@tsconfig/node14": "^1.0.0",
     "@types/auth0": "^2.33.3",
     "@types/aws-lambda": "^8.10.76",

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,7 +60,7 @@ provider:
               - - "arn:aws:ssm"
                 - !Ref AWS::Region
                 - !Ref AWS::AccountId
-                - parameter/propid/slack/main
+                - parameter/propid/slack/${self:provider.stage}
             - !Join
               - ":"
               - - "arn:aws:kms"
@@ -290,6 +290,10 @@ functions:
           path: '/admin/feedback'
           method: post
           cors: *default_cors
+
+      - http:
+          path: '/admin/feedback_reaction'
+          method: post
 
   idEvents:
     handler: src/idEvents.handler

--- a/serverless.yml
+++ b/serverless.yml
@@ -88,6 +88,7 @@ provider:
 
         - Effect: Allow
           Action:
+            - dynamodb:GetItem
             - dynamodb:PutItem
             - dynamodb:DeleteItem
             - dynamodb:Query

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -7,6 +7,7 @@ import jwks from 'jwks-rsa';
 
 import * as keys from './admin/keys';
 import * as feedback from './admin/feedback';
+import * as feedbackReaction from './admin/feedback_reaction';
 import { _handler as publicHandler } from './public';
 import { _handler as idQueryHandler } from './idQuery';
 
@@ -23,6 +24,12 @@ const jwksClient = jwks({
 });
 
 const _handler: Handler<PublicHandlerEvent, void | APIGatewayProxyResult> = async (event, context, callback) => {
+
+  // POST from Slack interaction
+  if (event.resource === '/admin/feedback_reaction' && event.httpMethod === 'POST') {
+    return feedbackReaction.handler(event);
+  }
+
   const headers = decapitalize(event.headers);
   const tokenHeader = headers['authorization'];
   if (!tokenHeader || !tokenHeader.match(/^bearer /i)) {

--- a/src/admin/blocks.ts
+++ b/src/admin/blocks.ts
@@ -1,0 +1,136 @@
+import { ActionsBlock, SectionBlock } from '@slack/types';
+
+const feedbackTypes: { [key: string]: string } = {
+  'idMerge': 'IDの統合依頼',
+  'idSplit': 'IDの分割依頼',
+  'locationFix': '緯度経度修正依頼',
+  'nameChange': '地名・住所・ビル名変更依頼',
+  'addBanchiGo': '番地または号の追加依頼',
+};
+
+export const idMergeBlock = (feedback: any) => {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `*${feedbackTypes[feedback.feedbackType] || feedback.feedbackType}*`,
+    },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*統合が必要なIDのリスト*\n${feedback.idMerge?.list}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*同じ物件であることの確認方法*\n${feedback.idMerge?.confirm}`,
+      },
+    ],
+  };
+};
+
+export const idSplitBlock = (feedback: any) => {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: 'test', // TODO: これを作る
+    },
+  };
+};
+
+export const locationFixBlock = (feedback: any) => {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `*${feedbackTypes[feedback.feedbackType] || feedback.feedbackType}*`,
+    },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*修正後の緯度と経度*\n\`${feedback.locationFix?.latLng}\``,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*建物の場所の確認方法*\n${feedback.locationFix?.confirm}`,
+      },
+    ],
+  };
+};
+
+export const nameChangeBlock = (feedback: any) => {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `*${feedbackTypes[feedback.feedbackType] || feedback.feedbackType}*`,
+    },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*変更内容*\n${feedback.nameChange?.contents}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*地名変更、住所変更の確認方法*\n${feedback.nameChange?.confirm}`,
+      },
+    ],
+  };
+};
+
+export const addBanchiGoBlock = (feedback: any) => {
+  return {
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: `*${feedbackTypes[feedback.feedbackType] || feedback.feedbackType}*`,
+    },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*新しい番地または号*\n${feedback.addBanchiGo?.contents}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*地名変更、住所変更の確認方法*\n${feedback.addBanchiGo?.confirm}`,
+      },
+    ],
+  };
+};
+
+export const markAsProcessedActionsBlocks = ({ PK, SK }: { PK: string, SK: string }): [SectionBlock, ActionsBlock] => {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'plain_text',
+        text: 'この修正依頼に対応して以下のボタンを押してください。',
+      },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: '完了済み',
+          },
+          style: 'primary',
+          value: JSON.stringify({ logId: { PK, SK } }),
+          action_id: 'markAsResolved',
+        },
+        {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: '不正なリクエスト',
+          },
+          style: 'danger',
+          value: JSON.stringify({ logId: { PK, SK } }),
+          action_id: 'markAsInvalid',
+        },
+      ],
+    },
+  ];
+};

--- a/src/admin/blocks.ts
+++ b/src/admin/blocks.ts
@@ -33,8 +33,18 @@ export const idSplitBlock = (feedback: any) => {
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: 'test', // TODO: これを作る
+      text: `*${feedbackTypes[feedback.feedbackType] || feedback.feedbackType}*`,
     },
+    fields: [
+      {
+        type: 'mrkdwn',
+        text: `*分離が必要なIDのリスト*\n${feedback.idSplit?.latLng}`,
+      },
+      {
+        type: 'mrkdwn',
+        text: `*別の物件であることの確認方法*\n${feedback.idMerge?.confirm}`,
+      },
+    ],
   };
 };
 

--- a/src/admin/blocks.ts
+++ b/src/admin/blocks.ts
@@ -1,4 +1,4 @@
-import { ActionsBlock, SectionBlock } from '@slack/types';
+import type { ActionsBlock, SectionBlock } from '@slack/types';
 
 const feedbackTypes: { [key: string]: string } = {
   'idMerge': 'IDの統合依頼',
@@ -18,11 +18,11 @@ export const idMergeBlock = (feedback: any) => {
     fields: [
       {
         type: 'mrkdwn',
-        text: `*統合が必要なIDのリスト*\n${feedback.idMerge?.list}`,
+        text: `*統合が必要なIDのリスト*\n${feedback.idMerge?.list || ''}`,
       },
       {
         type: 'mrkdwn',
-        text: `*同じ物件であることの確認方法*\n${feedback.idMerge?.confirm}`,
+        text: `*同じ物件であることの確認方法*\n${feedback.idMerge?.confirm || ''}`,
       },
     ],
   };
@@ -38,11 +38,11 @@ export const idSplitBlock = (feedback: any) => {
     fields: [
       {
         type: 'mrkdwn',
-        text: `*分離が必要なIDのリスト*\n${feedback.idSplit?.latLng}`,
+        text: `*別の物件の緯度経度*\n\`${feedback.idSplit?.latLng || ''}\``,
       },
       {
         type: 'mrkdwn',
-        text: `*別の物件であることの確認方法*\n${feedback.idMerge?.confirm}`,
+        text: `*別の物件であることの確認方法*\n${feedback.idSplit?.confirm || ''}`,
       },
     ],
   };
@@ -58,11 +58,11 @@ export const locationFixBlock = (feedback: any) => {
     fields: [
       {
         type: 'mrkdwn',
-        text: `*修正後の緯度と経度*\n\`${feedback.locationFix?.latLng}\``,
+        text: `*修正後の緯度と経度*\n\`${feedback.locationFix?.latLng || ''}\``,
       },
       {
         type: 'mrkdwn',
-        text: `*建物の場所の確認方法*\n${feedback.locationFix?.confirm}`,
+        text: `*建物の場所の確認方法*\n${feedback.locationFix?.confirm || ''}`,
       },
     ],
   };
@@ -78,11 +78,11 @@ export const nameChangeBlock = (feedback: any) => {
     fields: [
       {
         type: 'mrkdwn',
-        text: `*変更内容*\n${feedback.nameChange?.contents}`,
+        text: `*変更内容*\n${feedback.nameChange?.contents || ''}`,
       },
       {
         type: 'mrkdwn',
-        text: `*地名変更、住所変更の確認方法*\n${feedback.nameChange?.confirm}`,
+        text: `*地名変更、住所変更の確認方法*\n${feedback.nameChange?.confirm || ''}`,
       },
     ],
   };
@@ -98,11 +98,11 @@ export const addBanchiGoBlock = (feedback: any) => {
     fields: [
       {
         type: 'mrkdwn',
-        text: `*新しい番地または号*\n${feedback.addBanchiGo?.contents}`,
+        text: `*新しい番地または号*\n${feedback.addBanchiGo?.contents || ''}`,
       },
       {
         type: 'mrkdwn',
-        text: `*地名変更、住所変更の確認方法*\n${feedback.addBanchiGo?.confirm}`,
+        text: `*地名変更、住所変更の確認方法*\n${feedback.addBanchiGo?.confirm || ''}`,
       },
     ],
   };

--- a/src/admin/feedback_reaction.ts
+++ b/src/admin/feedback_reaction.ts
@@ -1,0 +1,54 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { URLSearchParams } from 'url';
+import axios from 'axios';
+import { createLog } from '../lib/dynamodb_logs';
+
+export const _handler = async (event: APIGatewayProxyEvent) => {
+  const { body } = event;
+  if (!body) {
+    throw new Error('Invalid body');
+  }
+  const payload = JSON.parse(new URLSearchParams(body).get('payload') || '');
+  const { actions: [ { action_id, value } ], response_url, user, message: { blocks } } = payload;
+  const { logId: { PK, SK } } = JSON.parse(value);
+  let review: string;
+  let reviewText: string;
+  blocks.pop();
+
+  if (action_id === 'markAsResolved') {
+    review = 'resolved';
+    reviewText = `修正依頼は <@${user.id}> によって処理済みとしてマークされました。`;
+  } else if (action_id === 'markAsInvalid') {
+    review = 'resolved';
+    reviewText = `修正依頼は <@${user.id}> によって拒絶されました。`;
+  } else {
+    throw new Error(`Unknown action_id ${action_id}.`);
+  }
+  blocks.push(
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: reviewText,
+      },
+    },
+  );
+  await Promise.all([
+    createLog('feedbackRequestReview', { feedbackLogId: { PK, SK }, review, slack_user: user.id }),
+    axios.post(response_url, {
+      delete_original: true,
+      response_type: 'in_channel',
+      text: review,
+      blocks,
+    }),
+  ]);
+
+  return {
+    isBase64Encoded: false,
+    statusCode: 204,
+    body: '',
+  };
+};
+
+export const handler = _handler;
+

--- a/src/admin/feedback_reaction.ts
+++ b/src/admin/feedback_reaction.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { URLSearchParams } from 'url';
 import axios from 'axios';
-import { createLog } from '../lib/dynamodb_logs';
+import { createLog, getLog } from '../lib/dynamodb_logs';
 
 export const _handler = async (event: APIGatewayProxyEvent) => {
   const { body } = event;
@@ -11,6 +11,11 @@ export const _handler = async (event: APIGatewayProxyEvent) => {
   const payload = JSON.parse(new URLSearchParams(body).get('payload') || '');
   const { actions: [ { action_id, value } ], response_url, user, message: { blocks } } = payload;
   const { logId: { PK, SK } } = JSON.parse(value);
+
+  if (!(await getLog(PK, SK))) {
+    throw new Error('Invalid log identifiers.');
+  }
+
   let review: string;
   let reviewText: string;
   blocks.pop();

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -6,7 +6,7 @@ import { authenticateEvent, extractApiKey } from './authentication';
 export type Decorator = (handler: PropIdHandler) => PropIdHandler;
 export interface LoggerContext extends Context {
   propIdLogger: {
-    background: Promise<void>[]
+    background: Promise<any>[]
   }
 };
 export const logger: Decorator = (handler) => {

--- a/src/lib/dynamodb_logs.ts
+++ b/src/lib/dynamodb_logs.ts
@@ -29,7 +29,7 @@ export const createLog = async (
   metadata: { [key: string]: any },
   userIdentifier: { apiKey?: string, userId?: string } = {},
   now: Date = new Date(),
-): Promise<void> => {
+): Promise<{ PK: string, SK: string }> => {
   const nowStr = now.toISOString();
   const datePart = nowStr.slice(0, 10);
   const PK = `LOG#${logIdentifier}#${datePart}`;
@@ -37,17 +37,21 @@ export const createLog = async (
 
   const { apiKey, userId } = userIdentifier;
 
+  const item = {
+    PK,
+    SK,
+    userId,
+    apiKey,
+    createAt: nowStr,
+    ...metadata,
+  };
+
   await DB.put({
     TableName,
-    Item: {
-      PK,
-      SK,
-      userId,
-      apiKey,
-      createAt: nowStr,
-      ...metadata,
-    },
+    Item: item,
   }).promise();
+
+  return item;
 };
 
 export const withLock = async <T = any>(lockId: string, inner: () => Promise<T>): Promise<T> => {

--- a/src/lib/dynamodb_logs.ts
+++ b/src/lib/dynamodb_logs.ts
@@ -54,7 +54,7 @@ export const createLog = async (
   return item;
 };
 
-export const getLog = async (PK: string, SK: string) => DB.get({
+export const getLog = (PK: string, SK: string) => DB.get({
   TableName,
   Key: { PK, SK },
 }).promise().catch(() => false);

--- a/src/lib/dynamodb_logs.ts
+++ b/src/lib/dynamodb_logs.ts
@@ -54,6 +54,12 @@ export const createLog = async (
   return item;
 };
 
+export const getLog = async (PK: string, SK: string) => DB.get({
+  TableName,
+  Key: { PK, SK },
+}).promise().catch(() => false);
+
+
 export const withLock = async <T = any>(lockId: string, inner: () => Promise<T>): Promise<T> => {
   // Get lock
   let tries = 0, lockAcquired = false;

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -7,7 +7,7 @@ let cachedWebhookUrl: string | undefined = undefined;
 export const sendSlackNotification = async (payload: IncomingWebhookSendArguments) => {
   if (typeof cachedWebhookUrl === 'undefined') {
     const parameterResp = await SSM.getParameter({
-      Name: '/propid/slack/main',
+      Name: `/propid/slack/${process.env.STAGE}`,
       WithDecryption: true,
     }).promise();
     cachedWebhookUrl = parameterResp.Parameter?.Value;


### PR DESCRIPTION
- Slack の incomming webhook を Slack App に変更（Interaction Component を使うため）
- ID 分割のフィードバックを受けた時の Slack 通知を追加
- フィードバックへのレビューの仕組みを追加。`feedbackRequestReview` のログを発行し、フィードバックに対するレビューをログテーブルに保存できるように変更。これで Athena でクエリして承認/拒否されたフィードバックの一覧が見れるようになる
- Slack の interaction でフィードバックへのレビューができるように変更
    - 現時点では手動でフィードバックへの対応を行い、その後にSlack の interaction でレビューする（承認/拒否のマークをつける）という運用を想定
    - 次に ID を分割できる仕組みを作ってから、可能なら Slack からその操作をできようにしたい