### PR TITLE
パーティションキーを取り除き、インフラ側の構成を変更せずに済むように修正

### DIFF
--- a/src/logEvents.test.ts
+++ b/src/logEvents.test.ts
@@ -130,7 +130,7 @@ test('should store address as s3 object', async () => {
 
   await logEvent._handler(event, {} as any, () => {})
 
-  expect(putObjectArgs[0].key).toMatch(/^addrdb_json\/pref=滋賀県\/city=大津市\/town=御陵町\/[0-9]*\.json\.gz$/)
+  expect(putObjectArgs[0].key).toMatch(/^addrdb_json\/滋賀県\/大津市\/御陵町\/[0-9]*\.json\.gz$/)
   const body0 = zlib.gunzipSync(putObjectArgs[0].body).toString('utf-8')
   expect(body0).toEqual(
     [
@@ -138,6 +138,9 @@ test('should store address as s3 object', async () => {
         id: '090f3d3379eba390e79ce53f2a3795e4',
         address: '滋賀県大津市御陵町',
         banchi_go: '1234-5678',
+        pref: '滋賀県',
+        city: '大津市',
+        town: '御陵町',
         json: JSON.stringify({ foo: 'bar' }),
       }
     ]

--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -63,12 +63,13 @@ export const _handler: DynamoDBStreamHandler = async (event) => {
         const address = logType;
         const banchi_go = SK;
         const { pref, city, town } = await normalize(address);
-        const key = `addrdb_json/pref=${pref}/city=${city}/town=${town}`;
+        // NOTE: no partitions
+        const key = `addrdb_json/${pref}/${city}/${town}`;
         if (!prev[key]) {
           prev[key] = [];
         }
         const id = md5hash(`${PK}${SK}`);
-        const logItem = { id, address, banchi_go, json: JSON.stringify(remainingItem) };
+        const logItem = { id, address, banchi_go, pref, city, town, json: JSON.stringify(remainingItem) };
         prev[key].push(logItem);
       }
     }


### PR DESCRIPTION
番地号データベースのデータ量は現在のところそこまで多くないことから、無理にパーティションを切らず Athena では常にスキャンするための修正です。