### PR TITLE
ジオコーディングに使えない文字を受け付けない

### DIFF
--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -386,6 +386,14 @@ $ curl -D /dev/stderr -G -H "x-access-token: <アクセストークン>" --data-
     <td>400</td>
     <td>Bad Request</td>
     <td>
+      <small>※ パラメーター <code>q</code> に使用できない文字が含まれている場合</small><br />
+      <code>{"message": "The parameter `q` contains an invalid character '/'."}</code>
+    </td>
+  </tr>
+    <tr>
+    <td>400</td>
+    <td>Bad Request</td>
+    <td>
         <small>※ 都道府県名が正規化できなかったケース</small><br />
         <code>{ "error": true, "error_code": "normalization_failed", "error_code_detail": "prefecture_not_recognized", "address": "あああ県" }</code>
       </td>

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -409,7 +409,7 @@ describe("normalization error cases",  () => {
     const event = {
       isDemoMode: true,
       queryStringParameters: {
-        q: '岩手県盛岡市盛岡駅西通２/９/１',
+        q: '岩手県盛岡市盛岡駅西通２-９-１ おはようビル2F/304',
       },
     }
     // @ts-ignore

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -403,6 +403,22 @@ describe("normalization error cases",  () => {
     expect(statusCode).toEqual(400)
     expect(message).toEqual('Missing querystring parameter `q`.')
   })
+
+  test('should handle invalid query characters.', async () => {
+
+    const event = {
+      isDemoMode: true,
+      queryStringParameters: {
+        q: '岩手県盛岡市盛岡駅西通２/９/１',
+      },
+    }
+    // @ts-ignore
+    const lambdaResult1 = await handler(event) as APIGatewayProxyResult
+    const { statusCode, body } = lambdaResult1
+    const { message } = JSON.parse(body)
+    expect(statusCode).toEqual(400)
+    expect(message).toEqual('The parameter `q` contains an invalid character \'/\'.')
+  })
 })
 
 test('should return 403 if not authenticated.', async () => {

--- a/src/public.ts
+++ b/src/public.ts
@@ -26,6 +26,9 @@ const IPC_NORMALIZATION_ERROR_CODE_DETAILS: { [key: string]: string } = {
   '-1': 'geo_undefined',
 };
 
+// アドレスクエリとして使用できない文字
+const IPC_INVALID_CHARS = ['/'];
+
 export const _handler: PropIdHandler = async (event, context) => {
   const address = event.queryStringParameters?.q;
   const ZOOM = parseInt(process.env.ZOOM, 10);
@@ -43,6 +46,12 @@ export const _handler: PropIdHandler = async (event, context) => {
   if (!address) {
     return errorResponse(400, 'Missing querystring parameter `q`.', quotaParams);
   }
+
+  const invalidAddressChar = IPC_INVALID_CHARS.find((char) => address.indexOf(char) !== -1);
+  if (invalidAddressChar) {
+    return errorResponse(400, `The parameter \`q\` contains an invalid character '${invalidAddressChar}'.`);
+  }
+
   Sentry.setContext('query', {
     address,
     debug: event.isDebugMode,


### PR DESCRIPTION
`/` が GT 社でのジオコーディングでサーバーエラーとなるため、あらかじめ確認して API はエラーを返すように修正。