### PR TITLE
内部番地号データベースに信頼できるデータが存在する場合はそちらを優先する

### DIFF
--- a/src/lib/dynamodb_logs.ts
+++ b/src/lib/dynamodb_logs.ts
@@ -116,7 +116,7 @@ export const withLock = async <T = any>(lockId: string, inner: () => Promise<T>)
   }
 };
 
-export const normalizeBanchiGo: (prenormalized: NormalizeResult) => Promise<NormalizeResult>
+export const normalizeBanchiGo: (prenormalized: NormalizeResult) => Promise<NormalizeResult & { int_geocoding_level?: number }>
   =
   async (nja: NormalizeResult) => {
     const dbItems = await DB.query({
@@ -139,6 +139,7 @@ export const normalizeBanchiGo: (prenormalized: NormalizeResult) => Promise<Norm
           ...nja,
           addr: item.SK,
           building: nja.addr.slice(item.SK.length).trim(),
+          int_geocoding_level: 0,
         };
         if (item.SK.indexOf('-') > 0) {
           // 番地号まで認識できた
@@ -150,6 +151,9 @@ export const normalizeBanchiGo: (prenormalized: NormalizeResult) => Promise<Norm
         if (typeof item.latLng !== 'undefined') {
           narrowedNormal.lat = parseFloat(item.latLng[0]);
           narrowedNormal.lng = parseFloat(item.latLng[1]);
+          if (!Number.isNaN(narrowedNormal.lat) && !Number.isNaN(narrowedNormal.lng)) {
+            narrowedNormal.int_geocoding_level = 8;
+          }
         }
         return narrowedNormal;
       }

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -594,6 +594,59 @@ describe('banchi-go database', () => {
       }
     });
   }
+
+  test('GT 社と正規化結果が競合するケース', async () => {
+
+    const pref = '東京都'
+    const city = '世田谷区'
+    const town = '北烏山六丁目'
+    const addrdbItem = {
+      PK: `AddrDB#${pref}${city}${town}`,
+      SK: '22-22',
+      latLng: [30, 134], // テストのための値
+    }
+    await dynamodb.DB.put({
+      TableName: process.env.AWS_DYNAMODB_LOG_TABLE_NAME,
+      Item: addrdbItem,
+    }).promise()
+
+    const inputAddr = '東京都世田谷区北烏山６－２２－２２ おはようビル'
+    const { apiKey, accessToken } = await dynamodb.createApiKey(`tries to create estate ID for ${inputAddr}`);
+    const event = {
+      queryStringParameters: {
+        q: inputAddr,
+        'api-key': apiKey,
+      },
+      headers: {
+        'X-Access-Token': accessToken,
+      },
+    };
+
+    // @ts-ignore
+    const lambdaResult = await handler(event);
+    // @ts-ignore
+    const [{ ID, ...other }] = JSON.parse(lambdaResult.body);
+
+    expect(ID).toBeDefined()
+    expect(other).toEqual({
+      "address": {
+        "ja": {
+          "address1": town,
+          "address2": "22-22",
+          "city": city,
+          "other": "おはようビル",
+          "prefecture": pref,
+        },
+      },
+      "geocoding_level": "8",
+      "location": {
+        lat: addrdbItem.latLng[0].toString(),
+        lng: addrdbItem.latLng[1].toString(),
+      },
+      "normalization_level": "8",
+      "status": null,
+    })
+  })
 });
 
 describe('Logging', () => {


### PR DESCRIPTION
当初は 「GT社ジオコーディング」 -> 「内部番地号データベース問い合わせ」 というステップを経ていたが、内部データベースのデータが存在する場合はそちらを利用するように修正。信頼できる緯度経度が存在すればそこからタイル ID を生成するように修正。