### PR TITLE
レスポンスの改善: 正規化住所や元の入力住所文字列を含める

### DIFF
--- a/docs/api-specs.md
+++ b/docs/api-specs.md
@@ -90,13 +90,28 @@ https://api.propid.jp/v1
         "city": "千代田区",
         "address1": "永田町一丁目",
         "address2": "7-1",
-        "other": "xxx ビル"
+        "other": "xxxビル"
       }
     }
-    "status": null | "addressPending"
+    "status": null | "addressPending",
+    "query": {
+      "input": "東京都千代田区永田町1-7-1 xxxビル",
+      "address": {
+        "ja": {
+          "prefecture": "東京都",
+          "city": "千代田区",
+          "address1": "永田町一丁目",
+          "address2": "7-1",
+          "other": "xxxビル"
+        }
+      }
+    }
   }
 ]
 ```
+
+- `query.input` フィールドは、クエリとして入力した住所文字列をそのまま返却します
+- `query.address.ja` フィールドは、クエリ文字列を正規化した結果を返却します
 
 #### 有料プラン
 
@@ -120,7 +135,20 @@ https://api.propid.jp/v1
       "lng": "経度"
     }
   },
-  "status": null | "addressPending"
+  "status": null | "addressPending",
+    "query": {
+      "input": "東京都千代田区永田町1-7-1 xxxビル",
+      "address": {
+        "ja": {
+          "prefecture": "東京都",
+          "city": "千代田区",
+          "address1": "永田町一丁目",
+          "address2": "7-1",
+          "other": "xxxビル"
+        }
+      }
+    }
+  }
 ]
 ```
 

--- a/src/idQuery/splitHandler.test.ts
+++ b/src/idQuery/splitHandler.test.ts
@@ -65,11 +65,11 @@ test('should generate new ID from that of existing.', async () => {
   const idObjects3 = JSON.parse(lambdaResult3.body);
   expect(idObjects3).toHaveLength(2);
   if (idObjects3[0].ID === idObj1.ID) {
-    expect(idObjects3[0]).toMatchObject(idObj1);
-    expect(idObjects3[1]).toMatchObject(idObj2);
+    expect(idObjects3[0].address.ja).toMatchObject(idObj1.address.ja);
+    expect(idObjects3[1].address.ja).toMatchObject(idObj2.address.ja);
   } else {
-    expect(idObjects3[0]).toMatchObject(idObj2);
-    expect(idObjects3[1]).toMatchObject(idObj1);
+    expect(idObjects3[0].address.ja).toMatchObject(idObj2.address.ja);
+    expect(idObjects3[1].address.ja).toMatchObject(idObj1.address.ja);
   }
 
   // ID を個別にクエリ
@@ -97,16 +97,16 @@ test('should generate new ID from that of existing.', async () => {
   const [idObj5] = JSON.parse(lambdaResult5.body);
 
   if (idObj4.ID === idObj1.ID) {
-    expect(idObj4).toMatchObject(idObj1);
+    expect(idObj4.address.ja).toMatchObject(idObj1.address.ja);
   } else {
-    expect(idObj5).toMatchObject(idObj1);
+    expect(idObj5.address.ja).toMatchObject(idObj1.address.ja);
   }
 
   if (idObj5.ID === idObjects3[0].ID) {
-    expect(idObj5).toMatchObject(idObjects3[0]);
-    expect(idObj4).toMatchObject(idObjects3[1]);
+    expect(idObj5.address.ja).toMatchObject(idObjects3[0].address.ja);
+    expect(idObj4.address.ja).toMatchObject(idObjects3[1].address.ja);
   } else {
-    expect(idObj5).toMatchObject(idObjects3[1]);
-    expect(idObj4).toMatchObject(idObjects3[0]);
+    expect(idObj5.address.ja).toMatchObject(idObjects3[1].address.ja);
+    expect(idObj4.address.ja).toMatchObject(idObjects3[0].address.ja);
   }
 });

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -77,7 +77,7 @@ describe('IncrementP Verification API', () => {
             }
           }
         ],
-        "attribution": "(c) GeoTechnologies Inc."
+        "attribution": "(c) GeoTechnologies, Inc."
       })
   })
 
@@ -115,7 +115,7 @@ describe('IncrementP Verification API', () => {
           }
         }
       ],
-      attribution: '(c) GeoTechnologies Inc.'
+      attribution: '(c) GeoTechnologies, Inc.'
     })
   })
 

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -745,6 +745,7 @@ describe('Logging', () => {
 test('レスポンスに元の住所などを含める', async () => {
   const inputAddr1 = '大阪府大阪市中央区大手前２丁目１−２２'
   const inputAddr2 = '大阪府大阪市中央区大手前２丁目１−２２ おはようビル303号室'
+  const inputAddr3 = '大阪府大阪市中央区大手前２丁目１番２２号'
   const { apiKey, accessToken } = await dynamodb.createApiKey(`tries to create estate ID for ${inputAddr1}`);
   const event1 = {
     queryStringParameters: { q: inputAddr1, 'api-key': apiKey },
@@ -754,28 +755,36 @@ test('レスポンスに元の住所などを含める', async () => {
     queryStringParameters: { q: inputAddr2, 'api-key': apiKey },
     headers: { 'X-Access-Token': accessToken },
   };
+  const event3 = {
+    queryStringParameters: { q: inputAddr3, 'api-key': apiKey },
+    headers: { 'X-Access-Token': accessToken },
+  };
 
   // @ts-ignore
   await handler(event1);
   // @ts-ignore
-  const lambdaResult = await handler(event2)
+  const lambdaResult2 = await handler(event2)
   // @ts-ignore
-  const [{ ID, address: { ja: addressObj }, query: query }] = JSON.parse(lambdaResult.body);
+  const lambdaResult3 = await handler(event3)
+  // @ts-ignore
+  const [{ query: query2 }] = JSON.parse(lambdaResult2.body);
+  // @ts-ignore
+  const [{ query: query3 }] = JSON.parse(lambdaResult3.body);
 
-  expect(ID).toBeDefined()
-  expect(addressObj).toEqual({
-      "address1": '大手前二丁目',
-      "address2": "1-22",
-      "city": '大阪市中央区',
-      "other": "",
-      "prefecture": '大阪府',
-  })
-  expect(query.input).toEqual(inputAddr2)
-  expect(query.address.ja).toEqual({
+  expect(query2.input).toEqual(inputAddr2)
+  expect(query3.input).toEqual(inputAddr3)
+  expect(query2.address.ja).toEqual({
     "address1": '大手前二丁目',
     "address2": "1-22",
     "city": '大阪市中央区',
     "other": "おはようビル303号室",
+    "prefecture": '大阪府',
+  })
+  expect(query3.address.ja).toEqual({
+    "address1": '大手前二丁目',
+    "address2": "1-22",
+    "city": '大阪市中央区',
+    "other": "",
     "prefecture": '大阪府',
   })
 })

--- a/src/public.ts
+++ b/src/public.ts
@@ -314,6 +314,18 @@ export const _handler: PropIdHandler = async (event, context) => {
           other: estateId.rawBuilding || '',
         },
       },
+      query: {
+        input: address,
+        address: {
+          ja: {
+            prefecture: finalNormalized.pref,
+            city: finalNormalized.city,
+            address1: finalNormalized.town,
+            address2: finalNormalized.addr,
+            other: finalNormalized.building || '',
+          },
+        },
+      },
       status: estateId.status === 'addressPending' ? 'addressPending' : null,
     };
     if (richIdResp) {


### PR DESCRIPTION
`query.input` フィールドと、正規化結果をそのまま返す `query.address.ja` フィールドを追加しました。