### PR TITLE
addressPending ステータスの場合の建物名の分離

### DIFF
--- a/src/lib/building_normalization.ts
+++ b/src/lib/building_normalization.ts
@@ -17,7 +17,7 @@ export const extractBuildingName: (
   const banchiGoPosInAddr = banchiGoOther.indexOf(banchiGo);
 
   if (ipc_geocoding_level_int === 5) {
-    const banchiGoRegex = new RegExp(`${banchiGo}(-([1-9][0-9]*))+`);
+    const banchiGoRegex = new RegExp(`${banchiGo}-[1-9][0-9]*`);
     const match = normalizedAddr.addr.match(banchiGoRegex);
     if (match) {
       const foundBanchiGo = match[0];

--- a/src/lib/building_normalization.ts
+++ b/src/lib/building_normalization.ts
@@ -16,8 +16,9 @@ export const extractBuildingName: (
   const ipc_geocoding_level_int = parseInt(geocoding_level, 10);
   const banchiGoPosInAddr = banchiGoOther.indexOf(banchiGo);
 
-  if (ipc_geocoding_level_int === 5) {
-    const banchiGoRegex = new RegExp(`${banchiGo}-[1-9][0-9]*`);
+  if (ipc_geocoding_level_int <= 5) {
+    const banchiPattern = ipc_geocoding_level_int === 5 ? banchiGo : '[1-9][0-9]*';
+    const banchiGoRegex = new RegExp(`${banchiPattern}(-[1-9][0-9]*)?`);
     const match = normalizedAddr.addr.match(banchiGoRegex);
     if (match) {
       const foundBanchiGo = match[0];

--- a/src/lib/building_normalization.ts
+++ b/src/lib/building_normalization.ts
@@ -17,7 +17,7 @@ export const extractBuildingName: (
   const banchiGoPosInAddr = banchiGoOther.indexOf(banchiGo);
 
   if (ipc_geocoding_level_int <= 5) {
-    const banchiPattern = ipc_geocoding_level_int === 5 ? banchiGo : '[1-9][0-9]*';
+    const banchiPattern = ipc_geocoding_level_int === 5 ? banchiGo : '[1-9][0-9]+';
     const banchiGoRegex = new RegExp(`${banchiPattern}(-[1-9][0-9]*)?`);
     const match = normalizedAddr.addr.match(banchiGoRegex);
     if (match) {
@@ -29,7 +29,12 @@ export const extractBuildingName: (
         building,
       };
     } else {
-      return normalizedAddr;
+      // どうやら normalizedAddr.addr は建物名のようだ
+      return {
+        ...normalizedAddr,
+        addr: '',
+        building: normalizedAddr.addr,
+      };
     }
 
   } else if (banchiGoPosInAddr >= 0) {

--- a/src/lib/building_normalization.ts
+++ b/src/lib/building_normalization.ts
@@ -12,9 +12,26 @@ export const extractBuildingName: (
   }
 
   const { addr: banchiGoOther } = normalizedAddr;
-  const { banchi_go: banchiGo } = geocodedAddr.feature.properties;
+  const { banchi_go: banchiGo, geocoding_level } = geocodedAddr.feature.properties;
+  const ipc_geocoding_level_int = parseInt(geocoding_level, 10);
   const banchiGoPosInAddr = banchiGoOther.indexOf(banchiGo);
-  if (banchiGoPosInAddr >= 0) {
+
+  if (ipc_geocoding_level_int === 5) {
+    const banchiGoRegex = new RegExp(`${banchiGo}(-([1-9][0-9]*))+`);
+    const match = normalizedAddr.addr.match(banchiGoRegex);
+    if (match) {
+      const foundBanchiGo = match[0];
+      const building = normalizedAddr.addr.replace(foundBanchiGo, '');
+      return {
+        ...normalizedAddr,
+        addr: foundBanchiGo,
+        building,
+      };
+    } else {
+      return normalizedAddr;
+    }
+
+  } else if (banchiGoPosInAddr >= 0) {
     const normAddrWithoutBuilding = {
       ...normalizedAddr,
       addr: banchiGoOther.slice(0, banchiGo.length + banchiGoPosInAddr),

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -539,7 +539,7 @@ describe('banchi-go database', () => {
     ['東京都文京区水道2丁目81 おはようビル', 'おはようビル',, { status: undefined }],
     ['東京都町田市木曽東四丁目81-イ22', '',, { status: undefined }],
     ['大阪府大阪市中央区久太郎町三丁目渡辺3小原流ホール', '小原流ホール',, { status: undefined }],
-    ['東京都文京区水道2丁目1-9999マンションGLV5NLV3', '', { geocoding_level: '5', normalization_level: '3' }, { status: 'addressPending' }],
+    ['東京都文京区水道2丁目1-9999マンションGLV5NLV3', 'マンションGLV5NLV3', { geocoding_level: '5', normalization_level: '3' }, { status: 'addressPending' }],
     ['東京都文京区水道2丁目1-9998マンションGLV5NLV8', 'マンションGLV5NLV8', { geocoding_level: '5', normalization_level: '8' }, { status: undefined }],
     ['大阪府高槻市富田町1-999-888マンションGLV4NLV3', '', { geocoding_level: '4', normalization_level: '3' }, { status: 'addressPending' }],
     ['京都府京都市右京区西院西貝川町100マンションGLV3NLV3', '', { geocoding_level: '3', normalization_level: '3' }, { status: 'addressPending' }],
@@ -815,7 +815,7 @@ test('小字と建物名の分離が正しくなされる', async () => {
   })
 })
 
-test.only('addressPending であっても、建物名と緯度経度が分離できる', async () => {
+test('addressPending であっても、建物名と緯度経度が分離できる', async () => {
   const addr1 = '東京都世田谷区新町二丁目18-8おはようビル 201号室'
   const addr2 = '東京都世田谷区新町二丁目18-8おはようビル'
   const addr3 = '東京都世田谷区新町二丁目18-8'

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -815,7 +815,7 @@ test('小字と建物名の分離が正しくなされる', async () => {
   })
 })
 
-test('addressPending であっても、建物名と緯度経度が分離できる', async () => {
+test('addressPending であっても、建物名と番地号が分離できる', async () => {
   const addr1 = '東京都世田谷区新町二丁目18-8おはようビル 201号室'
   const addr2 = '東京都世田谷区新町二丁目18-8おはようビル'
   const addr3 = '東京都世田谷区新町二丁目18-8'

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -814,3 +814,35 @@ test('小字と建物名の分離が正しくなされる', async () => {
     "other": "おはようビル"
   })
 })
+
+test.only('addressPending であっても、建物名と緯度経度が分離できる', async () => {
+  const addr1 = '東京都世田谷区新町二丁目18-8おはようビル 201号室'
+  const addr2 = '東京都世田谷区新町二丁目18-8おはようビル'
+  const addr3 = '東京都世田谷区新町二丁目18-8'
+  const { apiKey, accessToken } = await dynamodb.createApiKey(`tries to create estate ID for ${addr1}`);
+
+  const createEvent =  (addr: string) => ({
+    queryStringParameters: { q: addr, 'api-key': apiKey },
+    headers: { 'X-Access-Token': accessToken },
+  })
+
+  const events = [addr1, addr2, addr3].map(addr => createEvent(addr))
+
+  const bodies: any[] = []
+
+  for (const event of events) {
+    // @ts-ignore
+    const lambdaResult = await handler(event) as APIGatewayProxyResult
+    const body = JSON.parse(lambdaResult.body)
+    bodies.push(body[0])
+  }
+
+  const IDs = bodies.map(body => body.ID)
+  const statuses = bodies.map(body => body.status)
+  const addrObjects = bodies.map(body => body.address.ja)
+  const banchiGos = addrObjects.map(addrObj => addrObj.address2)
+
+  expect(statuses.every(status => status === 'addressPending')).toBe(true)
+  expect(banchiGos.every(banchiGo => banchiGo === '18-8')).toBe(true)
+  expect(IDs.every(id => id === IDs[0])).toBe(true)
+})

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -817,7 +817,7 @@ test('小字と建物名の分離が正しくなされる', async () => {
 
 describe('addressPending であっても、建物名と番地号が分離できる', () => {
 
-  const tester = async (addrs: string[], ExpectedBanchiGo: string) => {
+  const tester = async (addrs: string[], ExpectedBanchiGo: string, expectedBuilding: string) => {
     const { apiKey, accessToken } = await dynamodb.createApiKey(`tries to create estate ID for ${addrs[0]}`);
 
     const createEvent =  (addr: string) => ({
@@ -840,23 +840,25 @@ describe('addressPending であっても、建物名と番地号が分離でき�
     const statuses = bodies.map(body => body.status)
     const addrObjects = bodies.map(body => body.address.ja)
     const banchiGos = addrObjects.map(addrObj => addrObj.address2)
+    const buildings = addrObjects.map(addrObj => addrObj.other)
 
     expect(statuses.every(status => status === 'addressPending')).toBe(true)
     expect(banchiGos.every(banchiGo => banchiGo === ExpectedBanchiGo)).toBe(true)
     expect(IDs.every(id => id === IDs[0])).toBe(true)
+    expect(buildings.every(name => name === expectedBuilding))
   }
 
   test('その1', async () => {
     const addr1 = '東京都世田谷区新町二丁目18-8おはようビル 201号室'
     const addr2 = '東京都世田谷区新町二丁目18-8おはようビル'
     const addr3 = '東京都世田谷区新町二丁目18-8'
-    await tester([addr1, addr2, addr3], '18-8')
+    await tester([addr1, addr2, addr3], '18-8', 'おはようビル 201号室')
   })
 
   test('その2', async () => {
-    const addr1 = '世田谷区奥沢8-24-6こんにちはビル304'
+    const addr1 = '世田谷区奥沢8-24-6'
     const addr2 = '世田谷区奥沢8-24-6こんにちはビル'
-    const addr3 = '世田谷区奥沢8-24-6'
-    await tester([addr1, addr2, addr3], '24-6')
+    const addr3 = '世田谷区奥沢8-24-6こんにちはビル304'
+    await tester([addr1, addr2, addr3], '24-6', '')
   })
 })

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -541,8 +541,8 @@ describe('banchi-go database', () => {
     ['大阪府大阪市中央区久太郎町三丁目渡辺3小原流ホール', '小原流ホール',, { status: undefined }],
     ['東京都文京区水道2丁目1-9999マンションGLV5NLV3', 'マンションGLV5NLV3', { geocoding_level: '5', normalization_level: '3' }, { status: 'addressPending' }],
     ['東京都文京区水道2丁目1-9998マンションGLV5NLV8', 'マンションGLV5NLV8', { geocoding_level: '5', normalization_level: '8' }, { status: undefined }],
-    ['大阪府高槻市富田町1-999-888マンションGLV4NLV3', '', { geocoding_level: '4', normalization_level: '3' }, { status: 'addressPending' }],
-    ['京都府京都市右京区西院西貝川町100マンションGLV3NLV3', '', { geocoding_level: '3', normalization_level: '3' }, { status: 'addressPending' }],
+    ['大阪府高槻市富田町1-999-888マンションGLV4NLV3', 'マンションGLV4NLV3', { geocoding_level: '4', normalization_level: '3' }, { status: 'addressPending' }],
+    ['京都府京都市右京区西院西貝川町100マンションGLV3NLV3', 'マンションGLV3NLV3', { geocoding_level: '3', normalization_level: '3' }, { status: 'addressPending' }],
   ];
 
   for (const [inputAddr, building, expectedNormResult, expectedIdObject] of cases) {
@@ -860,5 +860,12 @@ describe('addressPending であっても、建物名と番地号が分離でき�
     const addr2 = '世田谷区奥沢8-24-6こんにちはビル'
     const addr3 = '世田谷区奥沢8-24-6こんにちはビル304'
     await tester([addr1, addr2, addr3], '24-6', '')
+  })
+
+  test('その3 - ジオコーディングレベル5未満', async () => {
+    const addr1 = '静岡県榛原郡吉田町神戸2205-1'
+    const addr2 = '静岡県榛原郡吉田町神戸2205-1こんにちはビル'
+    const addr3 = '静岡県榛原郡吉田町神戸2205-1こんにちはビル304'
+    await tester([addr1, addr2, addr3], '2205-1', '')
   })
 })

--- a/src/public.ts
+++ b/src/public.ts
@@ -215,8 +215,8 @@ export const _handler: PropIdHandler = async (event, context) => {
   }
 
   // ビル名が以前認識されていない(NJAレベルや、内部DBプロセスで)かつ、IPCのレベルが6以上だと `extractBuildingName` で抽出可能となります。
-  // また、IPCレベル5の場合、`extractBuldingName` は正規表現で番地号とビル名を抽出します。ただし、存在が保証された番地号に基づかずにロジックのみで処理を行うため、結果の `address2` プロパティに含まれるビル名は不正確なものである可能性があります。
-  if (typeof finalNormalized.building === 'undefined' && ipc_geocoding_level_int >= 5) {
+  // また、IPCレベル 3-5の場合、`extractBuldingName` は正規表現で番地号とビル名を抽出します。ただし、存在が保証された番地号に基づかずにロジックのみで処理を行うため、結果の `other` プロパティに含まれるビル名は不正確なものである可能性があります。
+  if (typeof finalNormalized.building === 'undefined' && ipc_geocoding_level_int >= 3) {
     const extractedBuilding = extractBuildingName(
       address,
       prenormalized,

--- a/src/public.ts
+++ b/src/public.ts
@@ -214,10 +214,9 @@ export const _handler: PropIdHandler = async (event, context) => {
     return errorResponse(500, 'Internal server error', quotaParams);
   }
 
-  // ビル名が以前認識されていない(NJAレベルや、内部DBプロセスで)かつ、IPCのレベルが6以上だと `extractBuildingName`
-  // で抽出可能となります。
-  // IPCレベル5の場合、ビル名の抽出は行わないため、 `address2` プロパティにビル名含まれたままになります。
-  if (typeof finalNormalized.building === 'undefined' && ipc_geocoding_level_int >= 6) {
+  // ビル名が以前認識されていない(NJAレベルや、内部DBプロセスで)かつ、IPCのレベルが6以上だと `extractBuildingName` で抽出可能となります。
+  // また、IPCレベル5の場合、`extractBuldingName` は正規表現で番地号とビル名を抽出します。ただし、存在が保証された番地号に基づかずにロジックのみで処理を行うため、結果の `address2` プロパティに含まれるビル名は不正確なものである可能性があります。
+  if (typeof finalNormalized.building === 'undefined' && ipc_geocoding_level_int >= 5) {
     const extractedBuilding = extractBuildingName(
       address,
       prenormalized,
@@ -251,7 +250,6 @@ export const _handler: PropIdHandler = async (event, context) => {
   // NOTE:
   // 番地・号を発見できなかったとき(最終正規化レベル <= 6 かつ IPC <=5)は `addressPending` としてマークされ、別途確認を行うことになります。
   // この住所は未知の番地・号か、あるいは単純に不正な入力値である可能性があります。
-  // また、ビル名の抽出ができないため、`address2` フィールドに番地・号とビル名が混在します。
   // 修正のプロセスにより住所文字列は変更される可能性があります。
   const status = finalNormalized.level <= 6 && ipc_geocoding_level_int <= 5 ? 'addressPending' : undefined;
 


### PR DESCRIPTION
以前は、 GT 社ジオコーダーで号レベルの住所の正規化ができた時にのみ、その情報を使って建物名の分離を行なっていました。
この変更は、 addressPending (番地レベルしか分からなかった)の時は正規表現で番地号の文字列を分離する修正です。
この変更により、住所に建物名があってもなくても同一の ID が発行されるようになります。